### PR TITLE
[Bugfix] Added missing `ACTIONBAR_PAGE_CHANGED` to `actionbar-reagents`

### DIFF
--- a/mods/actionbar-reagents.lua
+++ b/mods/actionbar-reagents.lua
@@ -22,6 +22,8 @@ module.enable = function(self)
   local reagentcounter = CreateFrame("Frame", "ShaguTweaksReagentCount", UIParent)
   reagentcounter:RegisterEvent("PLAYER_ENTERING_WORLD")
   reagentcounter:RegisterEvent("ACTIONBAR_SLOT_CHANGED")
+  reagentcounter:RegisterEvent("ACTIONBAR_PAGE_CHANGED")
+  reagentcounter:RegisterEvent("UPDATE_BONUS_ACTIONBAR")
   reagentcounter:RegisterEvent("BAG_UPDATE")
 
   reagentcounter:SetScript("OnEvent", function()


### PR DESCRIPTION
I have my water walking and Underwater Breathing on the 2nd action bar / bonus bar, and the reagents count did not update.

Adding these events solve that.

I see the same events also being used for the `"Macro Icons"` module.